### PR TITLE
Add support for leave oversubscription

### DIFF
--- a/small_small_hr/__init__.py
+++ b/small_small_hr/__init__.py
@@ -3,3 +3,5 @@ Main init file for small_small_hr
 """
 VERSION = (0, 1, 2)
 __version__ = '.'.join(str(v) for v in VERSION)
+# pylint: disable=invalid-name
+default_app_config = 'small_small_hr.apps.SmallSmallHrConfig'  # noqa

--- a/small_small_hr/settings.py
+++ b/small_small_hr/settings.py
@@ -11,3 +11,5 @@ SSHR_DAY_LEAVE_VALUES = {
     6: 0,  # Saturday
     7: 0,  # Sunday
 }
+SSHR_ALLOW_OVERSUBSCRIBE = True  # allow taking more leave days one has
+SSHR_DEFAULT_TIME = 7  # default time of the day for leave

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,7 +22,7 @@ INSTALLED_APPS = [
     'crispy_forms',
     'rest_framework',
     # custom
-    'small_small_hr.apps.SmallSmallHrConfig',
+    'small_small_hr',
 ]
 
 DATABASES = {

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -18,7 +18,8 @@ from small_small_hr.forms import (AnnualLeaveForm, ApplyLeaveForm,
                                   StaffProfileAdminCreateForm,
                                   StaffProfileAdminForm, StaffProfileUserForm,
                                   UserStaffDocumentForm)
-from small_small_hr.models import Leave, OverTime, StaffProfile
+from small_small_hr.models import (Leave, OverTime, StaffProfile,
+                                   get_taken_leave_days)
 from small_small_hr.serializers import StaffProfileSerializer
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -322,7 +323,7 @@ class TestForms(TestCase):
         request.session = {}
         request.user = AnonymousUser()
 
-        # 6 days of leave
+        # 1 day of leave
         start = datetime(
             2017, 6, 5, 7, 0, 0, tzinfo=pytz.timezone(settings.TIME_ZONE))
         end = datetime(
@@ -352,6 +353,11 @@ class TestForms(TestCase):
         self.assertEqual(Leave.PENDING, leave.status)
         self.assertEqual('', leave.comments)
         mock.assert_called_with(leave_obj=leave)
+        self.assertEqual(
+            1,
+            get_taken_leave_days(
+                staffprofile, Leave.PENDING, Leave.REGULAR, 2017, 2017)
+        )
 
     @override_settings(SSHR_DEFAULT_TIME=7)
     def test_leaveform_no_overlap(self):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -785,6 +785,7 @@ class TestForms(TestCase):
             form2.errors['end'][0]
         )
 
+    @override_settings(SSHR_ALLOW_OVERSUBSCRIBE=False)
     def test_leaveform_max_days(self):
         """
         Test leave days sufficient
@@ -828,6 +829,7 @@ class TestForms(TestCase):
             form.errors['end'][0]
         )
 
+    @override_settings(SSHR_ALLOW_OVERSUBSCRIBE=False)
     def test_leaveform_max_sick_days(self):
         """
         Test sick days sufficient


### PR DESCRIPTION
Add an option to let staff members apply for more leave days than they have.

Fix: #20 